### PR TITLE
Configurable glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ This gem provides a command-line interface which can be run like so:
 For example, `erblint --lint-all --enable-all-linters` will run all available
 linters on all ERB files in the current directory or its descendants (`**/*.html{+*,}.erb`).
 
+If you want to change the glob that is used, you can configure it by adding it to your config file as follows:
+
+```yaml
+---
+glob: **/*.{html,text,js}{+*,}.erb
+linters:
+  ErbSafety:
+    enabled: true
+    better_html_config: .better-html.yml
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+```
+
 ## Available linters
 
 `erb-lint` comes with linters on-board:


### PR DESCRIPTION
### The problem

Per [the readme file](https://github.com/Shopify/erb-lint/blob/3a2ee22877d2361ff2591b4f17a52430eecd496e/README.md#usage):

> `erblint --lint-all --enable-all-linters` will run all available linters on all ERB files in the current directory or its descendants `(**/*.html{+*,}.erb)`.

Unfortunately this glob does not encompass all ERB files for some projects. Notably, `.text.erb` and `.js.erb` files will not be linted.

### The culprit
[The relevant code](https://github.com/Shopify/erb-lint/blob/3a2ee22877d2361ff2591b4f17a52430eecd496e/lib/erb_lint/cli.rb#L14) is found in `cli.rb`.

The glob is defined as a class constant with no configuration possible.

### The solution
This PR changes the class constant to a private method. The private method first attempts to load a glob from [the configuration file](https://github.com/Shopify/erb-lint/tree/3a2ee22877d2361ff2591b4f17a52430eecd496e#configuration), if that fails it falls back on the existing default of `**/*.html{+*,}.erb`.

